### PR TITLE
importing exceptions now works

### DIFF
--- a/unifi/controller.py
+++ b/unifi/controller.py
@@ -13,7 +13,7 @@ from requests_toolbelt import SSLAdapter
 import urllib3
 urllib3.disable_warnings()
 
-import exceptions
+from . import exceptions
 
 
 class Controller(object):


### PR DESCRIPTION
Your upstream python package is broken. If i import the controller module it throws an exception because there is no package called `exceptions`. I fixed the import statement in your `controller` module.